### PR TITLE
Select formats based on index

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -5,6 +5,7 @@ This function is closely following the load_xdf reference implementation.
 Copyright (c) 2015-2018, Syntrogi Inc. dba Intheon
 """
 
+import collections
 import os
 import struct
 import itertools
@@ -170,10 +171,15 @@ def load_xdf(filename,
         """Temporary per-stream data."""
         def __init__(self, xml):
             """Init a new StreamData object from a stream header."""
-            fmt2char = {'int8': 'b', 'int16': 'h', 'int32': 'i', 'int64': 'q',
-                        'float32': 'f', 'double64': 'd'}
-            fmt2nbytes = {'int8': 1, 'int16': 2, 'int32': 4, 'int64': 8,
-                          'float32': 4, 'double64': 8}
+            fmts = collections.OrderedDict([
+                ('double64', np.float64),
+                ('float32', np.float32),
+                ('string', np.object),
+                ('int32', np.int32),
+                ('int16', np.int16),
+                ('int8', np.int8),
+                ('int64', np.int64)
+            ])
             # number of channels
             self.nchns = int(xml['info']['channel_count'][0])
             # nominal sampling rate in Hz
@@ -194,10 +200,11 @@ def load_xdf(filename,
             self.tdiff = 1.0 / self.srate if self.srate > 0 else 0.0
             # pre-calc some parsing parameters for efficiency
             if self.fmt != 'string':
+                # index of the format as in channel_format_t
+                self.fmtindex = list(fmts.keys()).index(self.fmt) + 1
+                self.dtype = np.dtype(fmts[self.fmt])
                 # number of bytes to read from stream to handle one sample
-                self.samplebytes = self.nchns * fmt2nbytes[self.fmt]
-                # format string to pass to struct.unpack() to handle one sample
-                self.structfmt = '<%s%s' % (self.nchns, fmt2char[self.fmt])
+                self.samplebytes = self.nchns * self.dtype.itemsize
 
     logger.info('Importing XDF file %s...' % filename)
     if not os.path.exists(filename):
@@ -288,7 +295,7 @@ def load_xdf(filename,
                                 values[k][ch] = raw.decode(errors='replace')
                     else:
                         # read a sample comprised of numeric values
-                        values = np.zeros((nsamples, temp[StreamId].nchns))
+                        values = np.zeros((nsamples, temp[StreamId].nchns), dtype=temp[StreamId].dtype)
                         # for each sample...
                         for k in range(nsamples):
                             # read or deduce time stamp
@@ -300,7 +307,11 @@ def load_xdf(filename,
                             temp[StreamId].last_timestamp = stamps[k]
                             # read the values
                             raw = f.read(temp[StreamId].samplebytes)
-                            values[k, :] = struct.unpack(temp[StreamId].structfmt, raw)
+                            # no fromfile(), see
+                            # https://github.com/numpy/numpy/issues/13319
+                            values[k, :] = np.frombuffer(raw,
+                                                         dtype=temp[StreamId].dtype,
+                                                         count=temp[StreamId].nchns)
                     logger.debug('  reading [%s,%s]' % (temp[StreamId].nchns,
                                                             nsamples))
                     # optionally send through the on_chunk function

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -5,7 +5,6 @@ This function is closely following the load_xdf reference implementation.
 Copyright (c) 2015-2018, Syntrogi Inc. dba Intheon
 """
 
-import collections
 import os
 import struct
 import itertools
@@ -171,7 +170,7 @@ def load_xdf(filename,
         """Temporary per-stream data."""
         def __init__(self, xml):
             """Init a new StreamData object from a stream header."""
-            fmts = collections.OrderedDict([
+            fmts = dict([
                 ('double64', np.float64),
                 ('float32', np.float32),
                 ('string', np.object),
@@ -200,8 +199,6 @@ def load_xdf(filename,
             self.tdiff = 1.0 / self.srate if self.srate > 0 else 0.0
             # pre-calc some parsing parameters for efficiency
             if self.fmt != 'string':
-                # index of the format as in channel_format_t
-                self.fmtindex = list(fmts.keys()).index(self.fmt) + 1
                 self.dtype = np.dtype(fmts[self.fmt])
                 # number of bytes to read from stream to handle one sample
                 self.samplebytes = self.nchns * self.dtype.itemsize


### PR DESCRIPTION
As a precursor for the chunk7 reader, use the same format ordering as in lsl and read in the native datatype (line 293)