### PR TITLE
Support NumPy < 1.14

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -536,7 +536,7 @@ def _jitter_removal(streams,
                     indices = np.arange(range_i[0], range_i[1] + 1, 1)[:, None]
                     X = np.concatenate((np.ones_like(indices), indices), axis=1)
                     y = stream.time_stamps[indices]
-                    mapping = np.linalg.lstsq(X, y, rcond=None)[0]
+                    mapping = np.linalg.lstsq(X, y, rcond=-1)[0]
                     stream.time_stamps[indices] = (mapping[0] + mapping[1] *
                                                    indices)
                     # Store num_samples and segment duration


### PR DESCRIPTION
This shouldn't make a huge difference since `rcond=-1` means machine precision, whereas `rcond=None` means machine precision times max(M, N). Fixes https://github.com/sccn/xdf/issues/22.