### PR TITLE
Move example to pyxdf folder, add optional command line argument

### DIFF
--- a/pyxdf/example.py
+++ b/pyxdf/example.py
@@ -1,10 +1,14 @@
 import os
 import logging
 import pyxdf
+import sys
 
 
 logging.basicConfig(level=logging.DEBUG)  # Use logging.INFO to reduce output.
-fname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'xdf_sample.xdf'))
+if len(sys.argv) > 1:
+    fname = sys.argv[1]
+else:
+    fname = os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..', 'xdf_sample.xdf'))
 streams, fileheader = pyxdf.load_xdf(fname)
 
 print("Found {} streams:".format(len(streams)))


### PR DESCRIPTION
Allow the example to be called from the installed module with an optional xdf file name, e.g. `python -m pyxdf.example` or `python -m pyxdf.example some_xdf_file.xdf`