### PR TITLE
Move code out of function body for less indentation and easier cythonization

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -22,6 +22,46 @@ __version__ = '1.14.0'
 logger = logging.getLogger(__name__)
 
 
+class StreamData:
+    """Temporary per-stream data."""
+
+    def __init__(self, xml):
+        """Init a new StreamData object from a stream header."""
+        fmts = dict([
+            ('double64', np.float64),
+            ('float32', np.float32),
+            ('string', np.object),
+            ('int32', np.int32),
+            ('int16', np.int16),
+            ('int8', np.int8),
+            ('int64', np.int64)
+        ])
+        # number of channels
+        self.nchns = int(xml['info']['channel_count'][0])
+        # nominal sampling rate in Hz
+        self.srate = round(float(xml['info']['nominal_srate'][0]))
+        # format string (int8, int16, int32, float32, double64, string)
+        self.fmt = xml['info']['channel_format'][0]
+        # list of time-stamp chunks (each an ndarray, in seconds)
+        self.time_stamps = []
+        # list of time-series chunks (each an ndarray or list of lists)
+        self.time_series = []
+        # list of clock offset measurement times (in seconds)
+        self.clock_times = []
+        # list of clock offset measurement values (in seconds)
+        self.clock_values = []
+        # last observed time stamp, for delta decompression
+        self.last_timestamp = 0.0
+        # nominal sampling interval, in seconds, for delta decompression
+        self.tdiff = 1.0 / self.srate if self.srate > 0 else 0.0
+        self.effective_srate = 0.0
+        # pre-calc some parsing parameters for efficiency
+        if self.fmt != 'string':
+            self.dtype = np.dtype(fmts[self.fmt])
+            # number of bytes to read from stream to handle one sample
+            self.samplebytes = self.nchns * self.dtype.itemsize
+
+
 def load_xdf(filename,
              on_chunk=None,
              synchronize_clocks=True,
@@ -166,43 +206,6 @@ def load_xdf(filename,
         OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
     """
-
-    class StreamData:
-        """Temporary per-stream data."""
-        def __init__(self, xml):
-            """Init a new StreamData object from a stream header."""
-            fmts = dict([
-                ('double64', np.float64),
-                ('float32', np.float32),
-                ('string', np.object),
-                ('int32', np.int32),
-                ('int16', np.int16),
-                ('int8', np.int8),
-                ('int64', np.int64)
-            ])
-            # number of channels
-            self.nchns = int(xml['info']['channel_count'][0])
-            # nominal sampling rate in Hz
-            self.srate = round(float(xml['info']['nominal_srate'][0]))
-            # format string (int8, int16, int32, float32, double64, string)
-            self.fmt = xml['info']['channel_format'][0]
-            # list of time-stamp chunks (each an ndarray, in seconds)
-            self.time_stamps = []
-            # list of time-series chunks (each an ndarray or list of lists)
-            self.time_series = []
-            # list of clock offset measurement times (in seconds)
-            self.clock_times = []
-            # list of clock offset measurement values (in seconds)
-            self.clock_values = []
-            # last observed time stamp, for delta decompression
-            self.last_timestamp = 0.0
-            # nominal sampling interval, in seconds, for delta decompression
-            self.tdiff = 1.0 / self.srate if self.srate > 0 else 0.0
-            # pre-calc some parsing parameters for efficiency
-            if self.fmt != 'string':
-                self.dtype = np.dtype(fmts[self.fmt])
-                # number of bytes to read from stream to handle one sample
-                self.samplebytes = self.nchns * self.dtype.itemsize
 
     logger.info('Importing XDF file %s...' % filename)
     if not os.path.exists(filename):


### PR DESCRIPTION
Screens have a limited width and Cython makes it easier to compile top level functions / classes so I moved the StreamData class and chunk 3 reader block out of the function body.

The next step would be a `pyxdf.pxd` file with annotations for Cython, leaving the [pure python](http://docs.cython.org/en/latest/src/tutorial/pure.html) code untouched.