### PR TITLE
Use Cython

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,7 @@ venv.bak/
 
 # PyCharm
 .idea
+
+# cython temporaries
+/pyxdf/pyxdf.c
+/pyxdf/pyxdf.html

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## [1.16.3] - 20XX-XX-XX
+### Added
+- Add cython type hints (requires optional local compilation) ([#17](https://github.com/xdf-modules/xdf-python/pull/17) by [Tristan Stenner](https://github.com/tstenner)).
 
 ## [1.16.2] - 2019-10-23
 ### Added

--- a/pyxdf/pyxdf.pxd
+++ b/pyxdf/pyxdf.pxd
@@ -1,0 +1,35 @@
+import cython
+
+# native replacements for potentially slow functions
+
+cdef class StreamData:
+    cdef readonly double tdiff, last_timestamp, srate
+    cdef readonly int nchns, samplebytes
+    cdef readonly fmt
+    cdef public double effective_srate
+    cdef public time_stamps, time_series, clock_times, clock_values, dtype, fmts
+
+cdef bytearray _read_varlen_int_buf
+
+cpdef load_xdf(filename,
+	select_streams=*,
+	on_chunk=*,
+	bint synchronize_clocks=*,
+	bint handle_clock_resets=*,
+	bint dejitter_timestamps=*,
+	double jitter_break_threshold_seconds=*,
+	int jitter_break_threshold_samples=*,
+	double clock_reset_threshold_seconds=*,
+	double clock_reset_threshold_stds=*,
+	double clock_reset_threshold_offset_seconds=*,
+	double clock_reset_threshold_offset_stds=*,
+	double winsor_threshold=*,
+	verbose=*)
+
+@cython.locals(nbytes=cython.uchar)
+cpdef inline cython.Py_ssize_t _read_varlen_int(f) except? 0
+
+
+@cython.locals(k=cython.Py_ssize_t, stamps=cython.double[:])
+cdef _read_chunk3(f, StreamData s)
+


### PR DESCRIPTION
As first approach to speed up the chunk 3 reading, I've added a pxd file so cython can use static types.

Usage: run `cythonize -3 -i -a pyxdf.py` in the pyxdf subfolder, import pyxdf as usual.

So far, it yields a speedup of about 16% (3.2s -> 2.7s), whereas my previous changes combined reduced the time from about 7s to 3.83s, so I'm not sure if it's worth it without replacing some functions with cython code.

**Edit**: It works with the python file classes, so gzip support is still there.