### PR TITLE
Include stream IDs in list of streams

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -346,6 +346,7 @@ def load_xdf(filename,
     for k in streams.keys():
         stream = streams[k]
         tmp = temp[k]
+        stream['info']['stream_id'] = k
         stream['info']['effective_srate'] = tmp.effective_srate
         stream['time_series'] = tmp.time_series
         stream['time_stamps'] = tmp.time_stamps

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -346,6 +346,11 @@ def load_xdf(filename,
     for k in streams.keys():
         stream = streams[k]
         tmp = temp[k]
+        if 'stream_id' in stream['info']:  # this is non-standard
+            logger.warning('Found existing "stream_id" key with value {} in '
+                           'StreamHeader XML. Using the "stream_id" value {} '
+                           'from the beginning of the StreamHeader chunk '
+                           'instead.'.format(stream['info']['stream_id'], k))
         stream['info']['stream_id'] = k
         stream['info']['effective_srate'] = tmp.effective_srate
         stream['time_series'] = tmp.time_series


### PR DESCRIPTION
The only way to uniquely identify a stream is to use its stream ID. Therefore, we should include this information in the returned list of streams (inside the `info` key under a new `stream_id` key). 