### PR TITLE
Fix loading long description in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-"""Python setup script for the pylsl distribution package."""
+"""Python setup script for the pyxdf distribution package."""
 
 from setuptools import setup, find_packages
 from codecs import open
@@ -23,7 +23,8 @@ setup(
     url='https://github.com/sccn/xdf',
 
     # Author details
-    author='Christian Kothe, Alejandro Ojeda, Tristan Stenner, Clemens Brunner',
+    author=('Christian Kothe, Alejandro Ojeda, Tristan Stenner, '
+            'Clemens Brunner'),
     author_email='christiankothe@gmail.com',
 
     # Choose your license

--- a/setup.py
+++ b/setup.py
@@ -2,10 +2,13 @@
 
 from setuptools import setup, find_packages
 from codecs import open
+from os import path
 
+
+here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open('README.md', encoding='utf-8') as f:
+with open(path.join(here, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,10 @@
 
 from setuptools import setup, find_packages
 from codecs import open
-from os import path
 
-
-here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the relevant file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open('README.md', encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
I think this needs to be changed because I get an error when I run `setup.py` locally. `README.md` is now in the same folder as `setup.py`, so going up a folder isn't correct. But I'm not 100% sure, please double-check.