### PR TITLE
Sort streams by stream_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [Unreleased]
 ### Added
 - Store unique stream ID inside the `["info"]["stream_id"]` dict value ([#19](https://github.com/xdf-modules/xdf-Python/pull/19) by [Clemens Brunner](https://github.com/cbrnr)).
+- Sort list of streams by stream ID ([#23](https://github.com/xdf-modules/xdf-Python/pull/23) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.15.1] - 2019-04-26
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## [Unreleased]
 ### Added
 - Store unique stream ID inside the `["info"]["stream_id"]` dict value ([#19](https://github.com/xdf-modules/xdf-Python/pull/19) by [Clemens Brunner](https://github.com/cbrnr)).
-- Sort list of streams by stream ID ([#23](https://github.com/xdf-modules/xdf-Python/pull/23) by [Clemens Brunner](https://github.com/cbrnr))
+- Sort list of streams by stream ID ([#23](https://github.com/xdf-modules/xdf-Python/pull/23) by [Clemens Brunner](https://github.com/cbrnr)).
 
 ## [1.15.1] - 2019-04-26
 ### Added

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -357,6 +357,7 @@ def load_xdf(filename,
         stream['time_stamps'] = tmp.time_stamps
 
     streams = [s for s in streams.values()]
+    streams.sort(key=lambda x: x["info"]["stream_id"])
     return streams, fileheader
 
 


### PR DESCRIPTION
Since we now store the unique stream IDs, we can just as well sort the list of streams now.