### PR TITLE
Add option to load only specific streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [1.15.2] - 2019-06-07
 ### Added
 - Store unique stream ID inside the `["info"]["stream_id"]` dict value ([#19](https://github.com/xdf-modules/xdf-Python/pull/19) by [Clemens Brunner](https://github.com/cbrnr)).
+- Add option to load only specific streams ([#24](https://github.com/xdf-modules/xdf-Python/pull/24) by [Clemens Brunner](https://github.com/cbrnr)).
 
 ## [1.15.1] - 2019-04-26
 ### Added

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -8,5 +8,5 @@ try:
 except DistributionNotFound:
     # package is not installed
     __version__ = None
-from .pyxdf import load_xdf, stream_info
+from .pyxdf import load_xdf, resolve_streams
 

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -8,5 +8,5 @@ try:
 except DistributionNotFound:
     # package is not installed
     __version__ = None
-from .pyxdf import load_xdf
+from .pyxdf import load_xdf, stream_info
 

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -1,12 +1,12 @@
 # Authors: Christian Kothe & the Intheon pyxdf team
+#          Clemens Brunner
 #
 # License: BSD (2-clause)
 
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    # package is not installed
+except DistributionNotFound:  # package is not installed
     __version__ = None
 from .pyxdf import load_xdf, resolve_streams, match_streaminfos
 

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -8,5 +8,5 @@ try:
 except DistributionNotFound:
     # package is not installed
     __version__ = None
-from .pyxdf import load_xdf, resolve_streams
+from .pyxdf import load_xdf, resolve_streams, match_streaminfos
 

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -600,3 +600,92 @@ def _robust_fit(A, y, rho=1, iters=1000):
         z = rho / (1 + rho) * d + 1 / (1 + rho) * tmp * d
         u = d - z
     return x
+
+
+def stream_info(fname):
+    return parse_chunks(parse_xdf(fname))
+
+
+def parse_xdf(fname):
+    """Parse and return chunks contained in an XDF file.
+
+    Parameters
+    ----------
+    fname : str
+        Name of the XDF file.
+
+    Returns
+    -------
+    chunks : list
+        List of all chunks contained in the XDF file.
+    """
+    chunks = []
+    with open(fname, "rb") as f:
+        if f.read(4) != b"XDF:":  # magic code
+            raise ValueError(f"Invalid XDF file {fname}.")
+        for chunk in _read_chunks(f):
+            chunks.append(chunk)
+    return chunks
+
+
+def parse_chunks(chunks):
+    """Parse chunks and extract information on individual streams."""
+    streams = []
+    for chunk in chunks:
+        if chunk["tag"] == 2:  # stream header chunk
+            streams.append(dict(stream_id=chunk["stream_id"],
+                                name=chunk.get("name"),  # optional
+                                type=chunk.get("type"),  # optional
+                                source_id=chunk.get("source_id"),  # optional
+                                created_at=chunk.get("created_at"),  # optional
+                                uid=chunk.get("uid"),  # optional
+                                session_id=chunk.get("session_id"),  # optional
+                                hostname=chunk.get("hostname"),  # optional
+                                channel_count=int(chunk["channel_count"]),
+                                channel_format=chunk["channel_format"],
+                                nominal_srate=int(chunk["nominal_srate"])))
+    return streams
+
+
+def _read_chunks(f):
+    """Read and yield XDF chunks.
+
+    Parameters
+    ----------
+    f : file handle
+        File handle of XDF file.
+
+
+    Yields
+    ------
+    chunk : dict
+        XDF chunk.
+    """
+    while True:
+        chunk = dict()
+        try:
+            nbytes = struct.unpack("B", f.read(1))[0]
+        except struct.error:
+            return  # reached EOF
+        if nbytes == 1:
+            chunk["nbytes"] = struct.unpack("B", f.read(1))[0]
+        elif nbytes == 4:
+            chunk["nbytes"] = struct.unpack("<I", f.read(4))[0]
+        elif nbytes == 8:
+            chunk["nbytes"] = struct.unpack("<Q", f.read(8))[0]
+        chunk["tag"] = struct.unpack('<H', f.read(2))[0]
+        if chunk["tag"] in [2, 3, 4, 6]:
+            chunk["stream_id"] = struct.unpack("<I", f.read(4))[0]
+            if chunk["tag"] == 2:  # parse StreamHeader chunk
+                xml = ET.fromstring(f.read(chunk["nbytes"] - 6).decode())
+                chunk = {**chunk, **_parse_streamheader(xml)}
+            else:  # skip remaining chunk contents
+                f.seek(chunk["nbytes"] - 6, 1)
+        else:
+            f.seek(chunk["nbytes"] - 2, 1)  # skip remaining chunk contents
+        yield chunk
+
+
+def _parse_streamheader(xml):
+    """Parse stream header XML."""
+    return {el.tag: el.text for el in xml if el.tag != "desc"}

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -95,18 +95,19 @@ def load_xdf(filename,
     Args:
         filename : name of the file to import (*.xdf or *.xdfz)
 
-        select_streams : One or more stream IDs to load. This can be an integer
-          integer, a list of integers or a list of dicts. For example,
-          select_streams=5 loads only the stream with stream ID 5, whereas
-          select_streams=[2, 4, 5] loads only the streams with stream IDs 2, 4,
-          and 5. If select_streams=[{'type': 'EEG'}] (a list of dicts), only
-          streams matching the query will be loaded (in this example, all
-          streams of type 'EEG'). Entries within a dict must all match a
-          stream, select_streams=[{'type': 'EEG', 'name': 'TestAMP'}] matches a
-          stream with both type 'EEG' *and* name 'TestAMP'. If
-          select_streams=[{'type': 'EEG'}, {'name': 'TestAMP'}], streams
-          matching either the type *or* the name will be loaded. If None, all
-          streams are loaded (default: None).
+        select_streams : int | list[int] | list[dict] | None
+          One or more stream IDs to load. Accepted values are:
+          - int or list[int]: load only specified stream IDs, e.g.
+            select_streams=5 loads only the stream with stream ID 5, whereas
+            select_streams=[2, 4] loads only streams with stream IDs 2 and 4.
+          - list[dict]: load only streams matching the query, e.g.
+            select_streams=[{'type': 'EEG'}] loads all streams of type 'EEG'.
+            Entries within a dict must all match a stream, e.g.
+            select_streams=[{'type': 'EEG', 'name': 'TestAMP'}] matches streams
+            with both type 'EEG' *and* name 'TestAMP'. If
+            select_streams=[{'type': 'EEG'}, {'name': 'TestAMP'}], streams
+            matching either the type *or* the name will be loaded.
+          - None: load all streams (default).
 
         synchronize_clocks : Whether to enable clock synchronization based on
           ClockOffset chunks. (default: true)

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -67,7 +67,7 @@ class StreamData:
 
 
 def load_xdf(filename,
-             load_only=None,
+             stream_ids=None,
              on_chunk=None,
              synchronize_clocks=True,
              handle_clock_resets=True,
@@ -95,9 +95,9 @@ def load_xdf(filename,
     Args:
         filename : name of the file to import (*.xdf or *.xdfz)
 
-        load_only : One or more stream IDs to load. This can be an integer or a
-          list of integers. For example, load_only=5 loads only the stream with
-          the stream ID 5, whereas load_only=[2, 4, 5] loads only the streams
+        stream_ids : One or more stream IDs to load. This can be an integer or
+          a list of integers. For example, load_only=5 loads only the stream
+          with stream ID 5, whereas load_only=[2, 4, 5] loads only the streams
           with stream IDs 2, 4, and 5. If None, all streams are loaded
           (default: None).
 
@@ -194,8 +194,8 @@ def load_xdf(filename,
         raise Exception('file %s does not exist.' % filename)
 
     # load_only contains the streams to load
-    if isinstance(load_only, int):
-        load_only = [load_only]  # put single stream id into list
+    if isinstance(stream_ids, int):
+        stream_ids = [stream_ids]  # put single stream id into list
 
     # dict of returned streams, in order of appearance, indexed by stream id
     streams = OrderedDict()
@@ -245,8 +245,8 @@ def load_xdf(filename,
 
             logger.debug(log_str)
 
-            if StreamId is not None and load_only is not None:
-                if StreamId not in load_only:
+            if StreamId is not None and stream_ids is not None:
+                if StreamId not in stream_ids:
                     f.read(chunklen - 2 - 4)  # skip remaining chunk contents
                     continue
 

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -95,15 +95,15 @@ def load_xdf(filename,
     Args:
         filename : name of the file to import (*.xdf or *.xdfz)
 
-        stream_ids : One or more stream IDs to load. This can be an integer, a
-          list of integers or a list of dicts.
-          For example, select_streams=5 loads only the stream with stream ID 5,
-          whereas select_streams=[2, 4, 5] loads only the streams with stream
-          IDs 2, 4, and 5. If select_streams=[{'type': 'EEG'}] (a list of
-          dicts), only streams matching the query will be loaded (in this
-          example, all streams of type 'EEG'). Entries within a dict must all
-          match a stream, select_streams=[{'type': 'EEG', 'name': 'TestAMP'}]
-          matches a stream with both type 'EEG' *and* name 'TestAMP'. If
+        select_streams : One or more stream IDs to load. This can be an integer
+          integer, a list of integers or a list of dicts. For example,
+          select_streams=5 loads only the stream with stream ID 5, whereas
+          select_streams=[2, 4, 5] loads only the streams with stream IDs 2, 4,
+          and 5. If select_streams=[{'type': 'EEG'}] (a list of dicts), only
+          streams matching the query will be loaded (in this example, all
+          streams of type 'EEG'). Entries within a dict must all match a
+          stream, select_streams=[{'type': 'EEG', 'name': 'TestAMP'}] matches a
+          stream with both type 'EEG' *and* name 'TestAMP'. If
           select_streams=[{'type': 'EEG'}, {'name': 'TestAMP'}], streams
           matching either the type *or* the name will be loaded. If None, all
           streams are loaded (default: None).

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -95,8 +95,11 @@ def load_xdf(filename,
     Args:
         filename : name of the file to import (*.xdf or *.xdfz)
 
-        load_only : One or more stream IDs to load. If None, all streams are
-           loaded (default: None).
+        load_only : One or more stream IDs to load. This can be an integer or a
+          list of integers. For example, load_only=5 loads only the stream with
+          the stream ID 5, whereas load_only=[2, 4, 5] loads only the streams
+          with stream IDs 2, 4, and 5. If None, all streams are loaded
+          (default: None).
 
         synchronize_clocks : Whether to enable clock synchronization based on
           ClockOffset chunks. (default: true)

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -97,16 +97,16 @@ def load_xdf(filename,
 
         stream_ids : One or more stream IDs to load. This can be an integer, a
           list of integers or a list of dicts.
-          For example, load_only=5 loads only the stream with stream ID 5,
-          whereas load_only=[2, 4, 5] loads only the streams with stream IDs 2,
-          4, and 5. If load_only=[{'type': 'EEG'}] (a list of dicts), only
-          streams matching the query will be loaded. Entries within a dict must
-          all match a stream, for example
-          load_only=[{'type': 'EEG', 'name': 'TestAMP'}] matches a stream with
-          both type 'EEG' *and* name 'TestAMP'.
-          If load_only=[{'type': 'EEG'}, {'name': 'TestAMP'}], streams matching
-          either the type *or* the name will be loaded.
-          If None, all streams are loaded (default: None).
+          For example, stream_ids=5 loads only the stream with stream ID 5,
+          whereas stream_ids=[2, 4, 5] loads only the streams with stream IDs
+          2, 4, and 5. If stream_ids=[{'type': 'EEG'}] (a list of dicts), only
+          streams matching the query will be loaded (in this example, all
+          streams of type 'EEG'). Entries within a dict must all match a
+          stream, for example stream_ids=[{'type': 'EEG', 'name': 'TestAMP'}]
+          matches a stream with both type 'EEG' *and* name 'TestAMP'. If
+          stream_ids=[{'type': 'EEG'}, {'name': 'TestAMP'}], streams matching
+          either the type *or* the name will be loaded. If None, all streams
+          are loaded (default: None).
 
         synchronize_clocks : Whether to enable clock synchronization based on
           ClockOffset chunks. (default: true)

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -204,7 +204,9 @@ def load_xdf(filename,
     # associated with the corresponding stream IDs
     # if select_streams is a list of dicts, use this to query and load streams
     # associated with these properties
-    if isinstance(select_streams, int):
+    if select_streams is None:
+        pass
+    elif isinstance(select_streams, int):
         select_streams = [select_streams]
     elif all([isinstance(elem, dict) for elem in select_streams]):
         select_streams = match_streaminfos(resolve_streams(filename),

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -602,6 +602,35 @@ def _robust_fit(A, y, rho=1, iters=1000):
     return x
 
 
+def match_streaminfos(stream_infos, parameters):
+    """Find stream IDs matching specified criteria.
+
+    Parameters
+    ----------
+    stream_infos : list of dicts
+        List of dicts containing information on each stream. This information
+        can be obtained using the function resolve_streams.
+    parameters : list of dicts
+        List of dicts containing key/values that should be present in streams.
+        Examples: [{"name": "Keyboard"}] matches all streams with a "name"
+                  field equal to "Keyboard".
+                  [{"name": "Keyboard"}, {"type": "EEG"}] matches all streams
+                  with a "name" field equal to "Keyboard" and all streams with
+                  a "type" field equal to "EEG".
+    """
+    matches = []
+    for request in parameters:
+        for info in stream_infos:
+            for key in request.keys():
+                match = info[key] == request[key]
+                if not match:
+                    break
+            if match:
+                matches.append(info['stream_id'])
+
+    return list(set(matches))  # return unique values
+
+
 def resolve_streams(fname):
     """Resolve streams in given XDF file.
 
@@ -612,7 +641,7 @@ def resolve_streams(fname):
 
     Returns
     -------
-    streams : list of dicts
+    stream_infos : list of dicts
         List of dicts containing information on each stream.
     """
     return parse_chunks(parse_xdf(fname))

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -602,7 +602,19 @@ def _robust_fit(A, y, rho=1, iters=1000):
     return x
 
 
-def stream_info(fname):
+def resolve_streams(fname):
+    """Resolve streams in given XDF file.
+
+    Parameters
+    ----------
+    fname : str
+        Name of the XDF file.
+
+    Returns
+    -------
+    streams : list of dicts
+        List of dicts containing information on each stream.
+    """
     return parse_chunks(parse_xdf(fname))
 
 


### PR DESCRIPTION
With the `load_only` argument, users can specify a stream ID or a list of stream IDs if they only want to load these specific streams. 