### PR TITLE
License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,25 +1,28 @@
 BSD 2-Clause License
 
-Copyright (c) 2015-2018, Syntrogi Inc. dba Intheon
+Copyright (c) 2015-2019, XDF-Python Development Team
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-* Redistributions of source code must retain the above copyright notice, this
-  list of conditions and the following disclaimer.
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
 
-* Redistributions in binary form must reproduce the above copyright notice,
-  this list of conditions and the following disclaimer in the documentation
-  and/or other materials provided with the distribution.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The views and conclusions contained in the software and documentation are those
+of the authors and should not be interpreted as representing official policies,
+either expressed or implied, of the XDF-Python project.

--- a/LICENSE
+++ b/LICENSE
@@ -1,28 +1,29 @@
 BSD 2-Clause License
 
-Copyright (c) 2015-2019, XDF-Python Development Team
+Copyright (c) 2015-2019, Intheon
+Copyright (c) 2018-2019, Chad Boulay
+Copyright (c) 2018-2019, Tristan Stenner
+Copyright (c) 2018-2019, Clemens Brunner
+
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:
 
-1. Redistributions of source code must retain the above copyright notice, this
-   list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright notice,
-   this list of conditions and the following disclaimer in the documentation
-   and/or other materials provided with the distribution.
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
 
-The views and conclusions contained in the software and documentation are those
-of the authors and should not be interpreted as representing official policies,
-either expressed or implied, of the XDF-Python project.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,11 +1,9 @@
 BSD 2-Clause License
 
-Copyright (c) 2015-2019, Intheon
+Copyright (c) 2015-2019, Syntrogi Inc. dba Intheon
 Copyright (c) 2018-2019, Chad Boulay
 Copyright (c) 2018-2019, Tristan Stenner
 Copyright (c) 2018-2019, Clemens Brunner
-
-All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are met:

--- a/pyxdf/__init__.py
+++ b/pyxdf/__init__.py
@@ -1,3 +1,7 @@
+# Authors: Christian Kothe & the Intheon pyxdf team
+#
+# License: BSD (2-clause)
+
 from pkg_resources import get_distribution, DistributionNotFound
 try:
     __version__ = get_distribution(__name__).version

--- a/pyxdf/example.py
+++ b/pyxdf/example.py
@@ -1,3 +1,8 @@
+# Authors: Christian Kothe & the Intheon pyxdf team
+#          Tristan Stenner
+#
+# License: BSD (2-clause)
+
 import os
 import logging
 import pyxdf

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -1,10 +1,9 @@
-# Authors: Syntrogi Inc. dba Intheon
+# Authors: Christian Kothe & the Intheon pyxdf team
 #          Chadwick Boulay
 #          Tristan Stenner
 #          Clemens Brunner
 #
 # License: BSD (2-clause)
-# Copyright (c) 2015-2019, XDF-Python Development Team
 
 """Defines the function load_xdf, which imports XDF files.
 

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -1,8 +1,15 @@
+# Authors: Syntrogi Inc. dba Intheon
+#          Clemens Brunner
+#          Tristan Stenner
+#          Chadwick Boulay
+#          <others?>
+#
+# License: BSD (2-clause)
+# Copyright (c) 2015-2019, XDF-Python Development Team
+
 """Defines the function load_xdf, which imports XDF files.
 
 This function is closely following the load_xdf reference implementation.
-
-Copyright (c) 2015-2018, Syntrogi Inc. dba Intheon
 """
 
 import os
@@ -175,35 +182,6 @@ def load_xdf(filename,
     Examples:
         load the streams contained in a given XDF file
         >>> streams, fileheader = load_xdf('C:\Recordings\myrecording.xdf')
-
-    License:
-        This file is covered by the BSD license.
-
-        Copyright (c) 2015-2018, Syntrogi Inc. dba Intheon
-
-        Redistribution and use in source and binary forms, with or without
-        modification, are permitted provided that the following conditions are
-        met:
-
-            * Redistributions of source code must retain the above copyright
-              notice, this list of conditions and the following disclaimer.
-            * Redistributions in binary form must reproduce the above copyright
-              notice, this list of conditions and the following disclaimer in
-              the documentation and/or other materials provided with the
-              distribution
-
-        THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-        "AS IS AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-        LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-        A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-        OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-        SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-        LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-        DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-        THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (
-        INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-        OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
     """
 
     logger.info('Importing XDF file %s...' % filename)

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -1,8 +1,7 @@
 # Authors: Syntrogi Inc. dba Intheon
-#          Clemens Brunner
-#          Tristan Stenner
 #          Chadwick Boulay
-#          <others?>
+#          Tristan Stenner
+#          Clemens Brunner
 #
 # License: BSD (2-clause)
 # Copyright (c) 2015-2019, XDF-Python Development Team

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
 
     # Author details
     author=('Christian Kothe, Tristan Stenner', 'Clemens Brunner'),
-    author_email='christiankothe@gmail.com',
+    author_email='christian.kothe@intheon.io',
 
     # Choose your license
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,8 @@
+# Authors: Christian Kothe & the Intheon pyxdf team
+#          Chadwick Boulay
+#
+# License: BSD (2-clause)
+
 """Python setup script for the pyxdf distribution package."""
 
 from setuptools import setup, find_packages
@@ -26,8 +31,7 @@ setup(
     url='https://github.com/sccn/xdf',
 
     # Author details
-    author=('Christian Kothe, Alejandro Ojeda, Tristan Stenner, '
-            'Clemens Brunner'),
+    author=('Christian Kothe, Tristan Stenner', 'Clemens Brunner'),
     author_email='christiankothe@gmail.com',
 
     # Choose your license


### PR DESCRIPTION
Fixes #25.

I think Syntrogi/Intheon should/must accept this change to replace the copyright holder "Syntrogi Inc. dba Intheon" with "XDF-Python Development Team" before we can merge this.

@trmullen are you OK with this change? Also, would you like to have the names of the contributors instead of Syntrogi in the authors list at the top of the file? I'd prefer to have @chkothe and anyone else who contributed from Syntrogi instead of the company name.