### PR TITLE
pytest with datafile

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -34,7 +34,7 @@ steps:
   displayName: 'Install Dependencies'
 
 - script: |
-    pip install pytest pytest-azurepipelines
+    pip install pytest pytest-azurepipelines pytest-datafiles
     pytest
   displayName: 'pytest'
 

--- a/pyxdf/test/test_library_basic.py
+++ b/pyxdf/test/test_library_basic.py
@@ -2,6 +2,7 @@ import pyxdf
 import pyxdf.pyxdf
 import pytest
 import io
+import os
 
 
 #%% test
@@ -24,3 +25,31 @@ def test_read_varlen_int():
     assert vla(b'\x08\xfd\x12\x00\x34\x12\x34\x56\x78') == 0x78563412340012fd
     with pytest.raises(RuntimeError):
         vla(b'\x00')
+
+
+FIXTURE_DIR = os.path.join(os.path.dirname(os.path.realpath(__file__)), 'test_files')
+
+
+@pytest.mark.datafiles(os.path.join(FIXTURE_DIR, 'xdf_sample.xdf'))
+def test_load_sample(datafiles):
+    for xdf_file in datafiles.listdir():
+        streams, fileheader = pyxdf.load_xdf(xdf_file)
+
+        stream_names = []
+        for strm in streams:
+            assert('info' in strm)
+            assert('name' in strm['info'])
+            assert(isinstance(strm['info']['name'], list))
+            stream_names.append(strm['info']['name'][0])
+            assert(stream_names[-1] in ['MousePosition', 'MouseButtons',
+                                        'Keyboard', 'AudioCaptureWin'])
+
+            assert('time_series' in strm)
+            import numpy as np
+            assert(isinstance(strm['time_series'], (np.ndarray, list)))
+            assert('time_stamps' in strm)
+            assert(isinstance(strm['time_stamps'], np.ndarray))
+            if isinstance(strm['time_series'], np.ndarray):
+                assert(strm['time_stamps'].shape[0] == strm['time_series'].shape[0])
+            else:
+                assert(strm['time_stamps'].shape[0] == len(strm['time_series']))


### PR DESCRIPTION
This is a first attempt. I would like to NOT include the datafile in the repo and instead download the file on demand. We can put the (small) datafile in a GitHub release, otherwise we need to host them somewhere.

@tstenner , how do you think we should get azure to download our test data? Within a script? Or within a pytest fixture? Something else?
