### PR TITLE
Preallocate the read buffer for numerical data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [1.16.2] - 2019-?
+### Changed
+- Speed up loading of numerical data ([#46](https://github.com/xdf-modules/xdf-python/pull/46) by [Tristan Stenner](https://github.com/tstenner))
+
 ## [1.16.1] - 2019-09-28
 ### Fixed
 - Remove Python 2 compatibility from `setup.py` ([#45](https://github.com/xdf-modules/xdf-Python/pull/45) by [Clemens Brunner](https://github.com/cbrnr)).

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -404,6 +404,8 @@ def _read_chunk3(f, s):
     else:
         # read a sample comprised of numeric values
         values = np.zeros((nsamples, s.nchns), dtype=s.dtype)
+        # read buffer
+        raw = bytearray(s.nchns * values.dtype.itemsize)
         # for each sample...
         for k in range(values.shape[0]):
             # read or deduce time stamp
@@ -413,7 +415,7 @@ def _read_chunk3(f, s):
                 stamps[k] = s.last_timestamp + s.tdiff
             s.last_timestamp = stamps[k]
             # read the values
-            raw = f.read(s.nchns * values.dtype.itemsize)
+            f.readinto(raw)
             # no fromfile(), see
             # https://github.com/numpy/numpy/issues/13319
             values[k, :] = np.frombuffer(raw,


### PR DESCRIPTION
For numerical chunks, each sample has a constant size, so this change allocates and reuses a read buffer to avoid one allocation per sample. With a large sample file (64 double channels, 1M samples) the total runtime decreases by 11% and the context switches by 98%.