### PR TITLE
Don't check srate for irregularly sampled streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## [1.16.2] - 2019-?
+### Fixed
+- Compare nominal to effective sampling rates only for regularly sampled streams ([#47](https://github.com/xdf-modules/xdf-Python/pull/47) by [Clemens Brunner](https://github.com/cbrnr)).
+
 ### Changed
-- Speed up loading of numerical data ([#46](https://github.com/xdf-modules/xdf-python/pull/46) by [Tristan Stenner](https://github.com/tstenner))
+- Speed up loading of numerical data ([#46](https://github.com/xdf-modules/xdf-python/pull/46) by [Tristan Stenner](https://github.com/tstenner)).
 
 ## [1.16.1] - 2019-09-28
 ### Fixed

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -592,11 +592,11 @@ def _jitter_removal(streams, threshold_seconds=1, threshold_samples=500):
                               stream.time_stamps[seg_starts])
                 stream.effective_srate = np.sum(counts) / np.sum(durations)
 
-        if np.abs(stream.srate - stream.effective_srate) / stream.srate > 0.1:
+        srate, effective_srate = stream.srate, stream.effective_srate
+        if srate != 0 and np.abs(srate - effective_srate) / srate > 0.1:
             msg = ("Stream {}: Calculated effective sampling rate {:.4f} Hz is"
                    " different from specified rate {} Hz.")
-            logger.warning(msg.format(stream_id, stream.effective_srate,
-                                      stream.srate))
+            logger.warning(msg.format(stream_id, effective_srate, srate))
 
     return streams
 

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -594,9 +594,9 @@ def _jitter_removal(streams, threshold_seconds=1, threshold_samples=500):
 
         srate, effective_srate = stream.srate, stream.effective_srate
         if srate != 0 and np.abs(srate - effective_srate) / srate > 0.1:
-            msg = ("Stream {}: Calculated effective sampling rate {:.4f} Hz is"
-                   " different from specified rate {} Hz.")
-            logger.warning(msg.format(stream_id, effective_srate, srate))
+            msg = ("Stream %d: Calculated effective sampling rate %.4f Hz is"
+                   " different from specified rate %.4f Hz.")
+            logger.warning(msg, stream_id, effective_srate, srate)
 
     return streams
 


### PR DESCRIPTION
If `stream.srate` is zero, we divided by zero in the effective vs. nominal srate check. This check should only be run for regularly sampled streams (i.e. with `stream.srate` > 0).