### PR TITLE
Allow loading from already opened file objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [1.16.2] - 2019-??-??
+### Added
+- Allow loading from already opened file objects, e.g. in-memory files or network streams ([#51](https://github.com/xdf-modules/xdf-python/pull/51) by [Tristan Stenner](https://github.com/tstenner)).
+
 ### Fixed
 - Compare nominal to effective sampling rates only for regularly sampled streams ([#47](https://github.com/xdf-modules/xdf-Python/pull/47) by [Clemens Brunner](https://github.com/cbrnr)).
 - More robust error recovery for compressed corrupted files ([#50](https://github.com/xdf-modules/xdf-python/pull/50) by [Tristan Stenner](https://github.com/tstenner)).

--- a/pyxdf/test/test_library_basic.py
+++ b/pyxdf/test/test_library_basic.py
@@ -24,3 +24,15 @@ def test_read_varlen_int():
     assert vla(b'\x08\xfd\x12\x00\x34\x12\x34\x56\x78') == 0x78563412340012fd
     with pytest.raises(RuntimeError):
         vla(b'\x00')
+
+
+def test_load_from_memory():
+    testfile = b'XDF:\01\n\02\00 \00\00\00<x/>'
+    f = pyxdf.pyxdf.open_xdf(io.BytesIO(testfile))
+    assert isinstance(f, io.BytesIO)
+    assert f.read()[-4:] == b'<x/>'
+
+    chunks = pyxdf.pyxdf.parse_xdf(io.BytesIO(testfile))
+    assert len(chunks) == 1
+    assert chunks[0]['stream_id'] == 32
+


### PR DESCRIPTION
Use case: `f = pyxdf.pyxdf.open_xdf(io.BytesIO(b'XDF:'))`

More realistically, this allows us to construct test files in memory and load them for unit tests and end-users can use any compression scheme which has a python wrapper, e.g. `pyxdf.pyxdf.open_xdf(zstd.open('somefile.xdf.zstd'))`.

The first two commits are from #50 which is needed for obvious reasons.