### PR TITLE
Suggestion: Require keyword-only arguments after the first two

### DIFF
--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -67,6 +67,7 @@ class StreamData:
 
 def load_xdf(filename,
              select_streams=None,
+             *,
              on_chunk=None,
              synchronize_clocks=True,
              handle_clock_resets=True,


### PR DESCRIPTION
Currently `load_xdf` has a lengthy list of args, and there's nothing keeping users from specifying several of those positionally. This means that, when we insert a new arg, the API contract (and potentially user code) breaks, unless we append them at end. 

While fine I think it helps discoverability & readability of the `load_xdf` docs if we allow ourselves the flexibility to insert new args earlier in the list. Plus, usage of `load_xdf` with more than a few positional args would be hard-to-read and error-prone call sites.