### PR TITLE
Handle a StreamId that can not be parsed correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Added
 - Add cython type hints (requires optional local compilation) ([#17](https://github.com/xdf-modules/xdf-python/pull/17) by [Tristan Stenner](https://github.com/tstenner)).
 
+### Fixed
+- Handle XDF files with corrupt chunk headers (missing stream IDs) more gracefully ([#62](https://github.com/xdf-modules/xdf-python/pull/62) by [Robert Guggenberger](https://github.com/agricolab))
+
 ### Changed
 - `load_xdf` now requires keyword-only arguments after the first two arguments ([#59](https://github.com/xdf-modules/xdf-python/pull/59) by [Christian Kothe](https://github.com/chkothe)).
 
@@ -16,7 +19,7 @@
 
 ### Changed
 - Speed up loading of numerical data ([#46](https://github.com/xdf-modules/xdf-python/pull/46) by [Tristan Stenner](https://github.com/tstenner)).
-- Avoid/suppress some NumPy warnings ([#48](https://github.com/xdf-modules/xdf-Python/pull/48) by [Clemens Brunner](https://github.com/cbrnr)). 
+- Avoid/suppress some NumPy warnings ([#48](https://github.com/xdf-modules/xdf-Python/pull/48) by [Clemens Brunner](https://github.com/cbrnr)).
 
 ## [1.16.1] - 2019-09-28
 ### Fixed

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -260,9 +260,7 @@ def load_xdf(filename,
             if tag in [2, 3, 4, 6]:
                 _streamid = f.read(4)
                 try:
-                    StreamId = struct.unpack("<I", _streamid)[0]
-                    log_str += ", StreamId={}".format(StreamId)
-                    logger.debug(log_str)
+                    StreamId = struct.unpack("<I", _streamid)[0]                    
                 except struct.error:
                     # we scan forward to next (hopefully) valid block in a bid
                     # to load as much of the file as possible
@@ -274,6 +272,10 @@ def load_xdf(filename,
                     logger.error(log_str)
                     _scan_forward(f)
                     continue
+                else:
+                    # to be executed if no exception was raised
+                    log_str += ", StreamId={}".format(StreamId)
+                    logger.debug(log_str)
 
             if StreamId is not None and select_streams is not None:
                 if StreamId not in select_streams:

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -256,11 +256,16 @@ def load_xdf(filename,
             # read [Tag]
             tag = struct.unpack('<H', f.read(2))[0]
             log_str = ' Read tag: {} at {} bytes, length={}'.format(tag, f.tell(), chunklen)
+            StreamId = None
             if tag in [2, 3, 4, 6]:
-                StreamId = struct.unpack('<I', f.read(4))[0]
-                log_str += ', StreamId={}'.format(StreamId)
-            else:
-                StreamId = None
+                _streamid = f.read(4)
+                try:
+                    StreamId = struct.unpack("<I", _streamid)[0]
+                    log_str += ", StreamId={}".format(StreamId)
+                except struct.error:
+                    StreamId = "StreamId missing"
+                    log_str += ", StreamId was missing"
+
 
             logger.debug(log_str)
 

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -262,12 +262,18 @@ def load_xdf(filename,
                 try:
                     StreamId = struct.unpack("<I", _streamid)[0]
                     log_str += ", StreamId={}".format(StreamId)
+                    logger.debug(log_str)
                 except struct.error:
-                    StreamId = "StreamId missing"
-                    log_str += ", StreamId was missing"
-
-
-            logger.debug(log_str)
+                    # we scan forward to next (hopefully) valid block in a bid
+                    # to load as much of the file as possible
+                    # If the StreamId could not be parsed correctly, it will be
+                    # None. We therefore also need to continue, because
+                    # otherwise we might end up in one the tag-specific branches
+                    # which expect a valid StreamId
+                    log_str += ", but StreamId is corrupt, scanning forward to next boundary chunk."
+                    logger.error(log_str)
+                    _scan_forward(f)
+                    continue
 
             if StreamId is not None and select_streams is not None:
                 if StreamId not in select_streams:


### PR DESCRIPTION
Resolve #61

Issue #61 reports that a specific file could not be loaded, as `unpack requires a buffer of 4 bytes` in line 260.
Inspection of the provided file showed an misconfigured StreamId message after the footer. The message was an empty byte `b''` instead of 4-bytes, so it could not be unpacked properly to an little-endian unsigned int. This part is now wrapped within a try-catch.

I tested it with the offending file, and `load_xdf` now is able to load it fully.