### PR TITLE
Parse stream info consistently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,37 +1,39 @@
 ## [1.16.3] - 20XX-XX-XX
 ### Added
-- Add cython type hints (requires optional local compilation) ([#17](https://github.com/xdf-modules/xdf-python/pull/17) by [Tristan Stenner](https://github.com/tstenner)).
+- Add Cython type hints (requires optional local compilation) ([#17](https://github.com/xdf-modules/xdf-python/pull/17) by [Tristan Stenner](https://github.com/tstenner))
 
 ### Fixed
 - Handle XDF files with corrupt chunk headers (missing stream IDs) more gracefully ([#62](https://github.com/xdf-modules/xdf-python/pull/62) by [Robert Guggenberger](https://github.com/agricolab))
 
+- Treat `nominal_srate` field as float to fix parsing errors ([#65](https://github.com/xdf-modules/xdf-python/pull/62) by [Robert Guggenberger](https://github.com/agricolab))
+
 ### Changed
-- `load_xdf` now requires keyword-only arguments after the first two arguments ([#59](https://github.com/xdf-modules/xdf-python/pull/59) by [Christian Kothe](https://github.com/chkothe)).
+- `load_xdf` now requires keyword-only arguments after the first two arguments ([#59](https://github.com/xdf-modules/xdf-python/pull/59) by [Christian Kothe](https://github.com/chkothe))
 
 ## [1.16.2] - 2019-10-23
 ### Added
-- Allow loading from already opened file objects, e.g. in-memory files or network streams ([#51](https://github.com/xdf-modules/xdf-python/pull/51) by [Tristan Stenner](https://github.com/tstenner)).
-- Add CI tests with example data ([#49](https://github.com/xdf-modules/xdf-Python/pull/49) by [Clemens Brunner](https://github.com/cbrnr)).
+- Allow loading from already opened file objects, e.g. in-memory files or network streams ([#51](https://github.com/xdf-modules/xdf-python/pull/51) by [Tristan Stenner](https://github.com/tstenner))
+- Add CI tests with example data ([#49](https://github.com/xdf-modules/xdf-Python/pull/49) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Fixed
-- Compare nominal to effective sampling rates only for regularly sampled streams ([#47](https://github.com/xdf-modules/xdf-Python/pull/47) by [Clemens Brunner](https://github.com/cbrnr)).
-- More robust error recovery for compressed corrupted files ([#50](https://github.com/xdf-modules/xdf-python/pull/50) by [Tristan Stenner](https://github.com/tstenner)).
+- Compare nominal to effective sampling rates only for regularly sampled streams ([#47](https://github.com/xdf-modules/xdf-Python/pull/47) by [Clemens Brunner](https://github.com/cbrnr))
+- More robust error recovery for compressed corrupted files ([#50](https://github.com/xdf-modules/xdf-python/pull/50) by [Tristan Stenner](https://github.com/tstenner))
 
 ### Changed
-- Speed up loading of numerical data ([#46](https://github.com/xdf-modules/xdf-python/pull/46) by [Tristan Stenner](https://github.com/tstenner)).
-- Avoid/suppress some NumPy warnings ([#48](https://github.com/xdf-modules/xdf-Python/pull/48) by [Clemens Brunner](https://github.com/cbrnr)).
+- Speed up loading of numerical data ([#46](https://github.com/xdf-modules/xdf-python/pull/46) by [Tristan Stenner](https://github.com/tstenner))
+- Avoid/suppress some NumPy warnings ([#48](https://github.com/xdf-modules/xdf-Python/pull/48) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.16.1] - 2019-09-28
 ### Fixed
-- Remove Python 2 compatibility from `setup.py` ([#45](https://github.com/xdf-modules/xdf-Python/pull/45) by [Clemens Brunner](https://github.com/cbrnr)).
+- Remove Python 2 compatibility from `setup.py` ([#45](https://github.com/xdf-modules/xdf-Python/pull/45) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.16.0] - 2019-09-27
 ### Added
-- Add option to load only specific streams ([#24](https://github.com/xdf-modules/xdf-Python/pull/24) by [Clemens Brunner](https://github.com/cbrnr)).
-- Add `verbose` argument to `load_xdf` ([#42](https://github.com/xdf-modules/xdf-Python/pull/42) by [Chadwick Boulay](https://github.com/cboulay)).
+- Add option to load only specific streams ([#24](https://github.com/xdf-modules/xdf-Python/pull/24) by [Clemens Brunner](https://github.com/cbrnr))
+- Add `verbose` argument to `load_xdf` ([#42](https://github.com/xdf-modules/xdf-Python/pull/42) by [Chadwick Boulay](https://github.com/cboulay))
 
 ### Fixed
-- Fixed bug in jitter removal ([#35](https://github.com/xdf-modules/xdf-python/pull/35) by [Alessandro D'Amico](https://github.com/ollie-d))
+- Fix bug in jitter removal ([#35](https://github.com/xdf-modules/xdf-python/pull/35) by [Alessandro D'Amico](https://github.com/ollie-d))
 - Add compatibility with Python 3.5 by converting Pathlike objects to str for file open functions ([#37](https://github.com/xdf-modules/xdf-python/pull/37) by [hankso](https://github.com/hankso))
 
 ### Changed
@@ -39,19 +41,19 @@
 
 ## [1.15.2] - 2019-06-07
 ### Added
-- Store unique stream ID inside the `["info"]["stream_id"]` dict value ([#19](https://github.com/xdf-modules/xdf-Python/pull/19) by [Clemens Brunner](https://github.com/cbrnr)).
+- Store unique stream ID inside the `["info"]["stream_id"]` dict value ([#19](https://github.com/xdf-modules/xdf-Python/pull/19) by [Clemens Brunner](https://github.com/cbrnr))
 
 ## [1.15.1] - 2019-04-26
 ### Added
-- Support pathlib objects ([#7](https://github.com/xdf-modules/xdf-Python/pull/7) by [Clemens Brunner](https://github.com/cbrnr)).
-- Allow example script to be called with an optional XDF file name (e.g. `python -m pyxdf.example` or `python -m pyxdf.example xdf_file.xdf`) ([#10](https://github.com/xdf-modules/xdf-Python/pull/10) by [Tristan Stenner](https://github.com/tstenner)).
+- Support pathlib objects ([#7](https://github.com/xdf-modules/xdf-Python/pull/7) by [Clemens Brunner](https://github.com/cbrnr))
+- Allow example script to be called with an optional XDF file name (e.g. `python -m pyxdf.example` or `python -m pyxdf.example xdf_file.xdf`) ([#10](https://github.com/xdf-modules/xdf-Python/pull/10) by [Tristan Stenner](https://github.com/tstenner))
 
 ### Fixed
-- Use correct data types ([#2](https://github.com/xdf-modules/xdf-Python/pull/2) by [Tristan Stenner](https://github.com/tstenner)).
-- Streams are not sorted by name anymore ([#3](https://github.com/xdf-modules/xdf-Python/pull/3) by [Clemens Brunner](https://github.com/cbrnr)).
-- Support older NumPy versions < 1.14 ([#4](https://github.com/xdf-modules/xdf-Python/pull/4) by [Clemens Brunner](https://github.com/cbrnr)).
-- Pass correct on_chunk argument ([#5](https://github.com/xdf-modules/xdf-Python/pull/5) by [Clemens Brunner](https://github.com/cbrnr)).
-- Fix _scan_forward ([#6](https://github.com/xdf-modules/xdf-Python/pull/6) by [Clemens Brunner](https://github.com/cbrnr)).
+- Use correct data types ([#2](https://github.com/xdf-modules/xdf-Python/pull/2) by [Tristan Stenner](https://github.com/tstenner))
+- Streams are not sorted by name anymore ([#3](https://github.com/xdf-modules/xdf-Python/pull/3) by [Clemens Brunner](https://github.com/cbrnr))
+- Support older NumPy versions < 1.14 ([#4](https://github.com/xdf-modules/xdf-Python/pull/4) by [Clemens Brunner](https://github.com/cbrnr))
+- Pass correct on_chunk argument ([#5](https://github.com/xdf-modules/xdf-Python/pull/5) by [Clemens Brunner](https://github.com/cbrnr))
+- Fix `_scan_forward` ([#6](https://github.com/xdf-modules/xdf-Python/pull/6) by [Clemens Brunner](https://github.com/cbrnr))
 
 ### Changed
-- Pull `StreamData` class and chunk 3 reader out of `load_xdf` ([#13](https://github.com/xdf-modules/xdf-Python/pull/13) by [Tristan Stenner](https://github.com/tstenner)).
+- Pull `StreamData` class and chunk 3 reader out of `load_xdf` ([#13](https://github.com/xdf-modules/xdf-Python/pull/13) by [Tristan Stenner](https://github.com/tstenner))

--- a/pyxdf/pyxdf.py
+++ b/pyxdf/pyxdf.py
@@ -789,6 +789,7 @@ def parse_chunks(chunks):
     streams = []
     for chunk in chunks:
         if chunk["tag"] == 2:  # stream header chunk
+            # if you edit, check for consistency with parsing in load_xdf
             streams.append(
                 dict(
                     stream_id=chunk["stream_id"],
@@ -801,7 +802,7 @@ def parse_chunks(chunks):
                     hostname=chunk.get("hostname"),  # optional
                     channel_count=int(chunk["channel_count"]),
                     channel_format=chunk["channel_format"],
-                    nominal_srate=int(chunk["nominal_srate"]),
+                    nominal_srate=round(float(chunk["nominal_srate"])),
                 )
             )
     return streams
@@ -831,7 +832,9 @@ def _read_chunks(f):
         if chunk["tag"] in [2, 3, 4, 6]:
             chunk["stream_id"] = struct.unpack("<I", f.read(4))[0]
             if chunk["tag"] == 2:  # parse StreamHeader chunk
-                xml = fromstring(f.read(chunk["nbytes"] - 6).decode())
+                # if you edit, check for consistency with parsing in load_xdf
+                msg = f.read(chunk["nbytes"] - 6).decode("utf-8", "replace")
+                xml = fromstring(msg)
                 chunk = {**chunk, **_parse_streamheader(xml)}
             else:  # skip remaining chunk contents
                 f.seek(chunk["nbytes"] - 6, 1)


### PR DESCRIPTION
Parsing and decoding was handled differently in load_xdf
versus parse_chunks. This commit aligns the behavior to the
load_xdf implementation, because sometimes, the casting as int
fails because the str is not an int literal

Should also resolve #64